### PR TITLE
Gi 403 med begrunnelse til fastlegefront ved ikke tilgang

### DIFF
--- a/src/main/java/no/nav/syfo/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/syfo/config/ApplicationConfig.java
@@ -1,5 +1,6 @@
 package no.nav.syfo.config;
 
+import no.nav.syfo.exception.RestTemplateErrorHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.*;
@@ -18,18 +19,19 @@ import static java.util.Arrays.asList;
 
 })
 @Profile("remote")
-public class ApplicationConfig{
+public class ApplicationConfig {
 
     @Bean(name = "Oidc")
     public RestTemplate restTemplate(ClientHttpRequestInterceptor... interceptors) {
         RestTemplate template = new RestTemplate();
         template.setInterceptors(asList(interceptors));
+        template.setErrorHandler(new RestTemplateErrorHandler());
         return template;
     }
 
     @Bean(name = "BasicAuth")
     public RestTemplate basicAuthRestTemplate(@Value("${srvfastlegerest.username}") String username,
-    @Value("${srvfastlegerest.password}") String password) {
+                                              @Value("${srvfastlegerest.password}") String password) {
         return new RestTemplateBuilder()
                 .basicAuthorization(username, password)
                 .build();

--- a/src/main/java/no/nav/syfo/domain/Tilgang.java
+++ b/src/main/java/no/nav/syfo/domain/Tilgang.java
@@ -1,0 +1,13 @@
+package no.nav.syfo.domain;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(fluent = true)
+@EqualsAndHashCode
+public class Tilgang {
+    public boolean harTilgang;
+    public String begrunnelse = "";
+}

--- a/src/main/java/no/nav/syfo/exception/ControllerExceptionHandler.java
+++ b/src/main/java/no/nav/syfo/exception/ControllerExceptionHandler.java
@@ -20,7 +20,6 @@ import javax.ws.rs.ForbiddenException;
 public class ControllerExceptionHandler {
 
     private final static String BAD_REQUEST_MSG = "Vi kunne ikke tolke inndataene";
-    public final static String FORBIDDEN_MSG = "Har ikke tilgang";
     private final static String INTERNAL_MSG = "Det skjedde en uventet feil";
     private final static String UNAUTHORIZED_MSG = "Autorisasjonsfeil";
 
@@ -66,6 +65,7 @@ public class ControllerExceptionHandler {
         } else {
             HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
 
+            log.warn("Fikk RuntimeException i én av controllerene");
             return handleExceptionInternal(ex, new ApiError(status.value(), INTERNAL_MSG), headers, status, request);
         }
     }
@@ -76,7 +76,7 @@ public class ControllerExceptionHandler {
 
     private ResponseEntity<ApiError> handleForbiddenException(ForbiddenException ex, HttpHeaders headers, WebRequest request) {
         HttpStatus status = HttpStatus.FORBIDDEN;
-        return handleExceptionInternal(ex, new ApiError(status.value(), FORBIDDEN_MSG), headers, status, request);
+        return handleExceptionInternal(ex, new ApiError(status.value(), ex.getMessage()), headers, status, request);
     }
 
     private ResponseEntity<ApiError> handleIllegalArgumentException(IllegalArgumentException ex, HttpHeaders headers, WebRequest request) {

--- a/src/main/java/no/nav/syfo/exception/RestTemplateErrorHandler.java
+++ b/src/main/java/no/nav/syfo/exception/RestTemplateErrorHandler.java
@@ -1,0 +1,34 @@
+package no.nav.syfo.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+
+import java.io.IOException;
+
+@Slf4j
+public class RestTemplateErrorHandler implements ResponseErrorHandler {
+    @Override
+    public boolean hasError(ClientHttpResponse httpResponse) throws IOException {
+        switch (httpResponse.getStatusCode().series()) {
+            case SUCCESSFUL:
+                return false;
+            case CLIENT_ERROR:
+                return httpResponse.getStatusCode() != HttpStatus.FORBIDDEN;
+            default:
+                return true;
+        }
+    }
+
+    @Override
+    public void handleError(ClientHttpResponse httpResponse) throws IOException {
+        if (httpResponse.getStatusCode().series() == HttpStatus.Series.SERVER_ERROR) {
+            log.error("Fikk en server error fra syfo-tilgangskontroll statusCode: {}, statusText: {}, body: {}", httpResponse.getStatusCode(), httpResponse.getStatusText(), httpResponse.getBody());
+            throw new RuntimeException("Fikk en server error fra syfo-tilgangskontroll");
+        } else if (httpResponse.getStatusCode().series() == HttpStatus.Series.CLIENT_ERROR) {
+            log.error("Fikk en client error fra syfo-tilgangskontroll, som ikke er forbidden statusCode: {}, statusText: {}, body: {}", httpResponse.getStatusCode(), httpResponse.getStatusText(), httpResponse.getBody());
+            throw new RuntimeException("Noe gikk galt ved henting av tilgang fra syfo-tilgangskontroll");
+        }
+    }
+}

--- a/src/main/java/no/nav/syfo/mappers/TilgangMappers.java
+++ b/src/main/java/no/nav/syfo/mappers/TilgangMappers.java
@@ -1,0 +1,21 @@
+package no.nav.syfo.mappers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import no.nav.syfo.domain.Tilgang;
+import org.springframework.http.ResponseEntity;
+
+@Slf4j
+public class TilgangMappers {
+    public static Tilgang rs2Tilgang(ResponseEntity<String> response) {
+        ObjectMapper mapper = new ObjectMapper();
+        Tilgang tilgang;
+        try {
+            tilgang = mapper.readValue(response.getBody(), Tilgang.class);
+        } catch (Exception e) {
+            log.error("Fikk en exception ved lesing av json fra syfo-tilgangskontroll", e);
+            throw new RuntimeException("Lesing av json fra syfo-tilgangskontroll feilet", e);
+        }
+        return tilgang;
+    }
+}

--- a/src/main/java/no/nav/syfo/rest/ressurser/FastlegeRessurs.java
+++ b/src/main/java/no/nav/syfo/rest/ressurser/FastlegeRessurs.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import lombok.extern.slf4j.Slf4j;
 import no.nav.security.oidc.api.ProtectedWithClaims;
 import no.nav.syfo.domain.Fastlege;
+import no.nav.syfo.domain.Tilgang;
 import no.nav.syfo.metric.Metrikk;
 import no.nav.syfo.services.FastlegeService;
 import no.nav.syfo.services.TilgangService;
@@ -58,9 +59,10 @@ public class FastlegeRessurs {
     }
 
     private void kastExceptionHvisIkkeTilgang(String fnr) {
-        if (tilgangService.harIkkeTilgang(fnr)) {
-            log.info("Har ikke tilgang til å se fastlegeinformasjon om brukeren.");
-            throw new HarIkkeTilgang();
+        Tilgang tilgang = tilgangService.sjekkTilgang(fnr);
+        if (!tilgang.harTilgang) {
+            log.info("Har ikke tilgang til å se fastlegeinformasjon om brukeren");
+            throw new HarIkkeTilgang(tilgang.begrunnelse);
         }
     }
 }

--- a/src/main/java/no/nav/syfo/services/exceptions/HarIkkeTilgang.java
+++ b/src/main/java/no/nav/syfo/services/exceptions/HarIkkeTilgang.java
@@ -4,8 +4,8 @@ import javax.ws.rs.ForbiddenException;
 
 public class HarIkkeTilgang extends ForbiddenException {
 
-    public HarIkkeTilgang() {
-        super();
+    public HarIkkeTilgang(String message) {
+        super(message);
     }
 }
 

--- a/src/test/java/no/nav/syfo/rest/ressurser/FastlegeRessursTest.java
+++ b/src/test/java/no/nav/syfo/rest/ressurser/FastlegeRessursTest.java
@@ -21,7 +21,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.RestTemplate;
 
-import static no.nav.syfo.exception.ControllerExceptionHandler.FORBIDDEN_MSG;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -124,7 +123,7 @@ public class FastlegeRessursTest {
     }
 
     private String mockApiError403() throws JSONException {
-        return mockApiErrorAsJson(403, FORBIDDEN_MSG);
+        return mockApiErrorAsJson(403, "GEOGRAFISK");
     }
 
     private String mockApiError404() throws JSONException {

--- a/src/test/java/no/nav/syfo/rest/ressurser/MockUtils.java
+++ b/src/test/java/no/nav/syfo/rest/ressurser/MockUtils.java
@@ -77,12 +77,18 @@ public class MockUtils {
     }
 
     static void mockResponseFraTilgangskontroll(RestTemplate restTemplate, HttpStatus httpStatus) {
-        ResponseEntity<Object> responseEntity200 = new ResponseEntity<>(httpStatus);
+        String okJson = "{\"harTilgang\":true, \"begrunnelse\":\"\"}";
+        String forbiddenJson = "{\"harTilgang\":false, \"begrunnelse\":\"GEOGRAFISK\"}";
+
+        ResponseEntity<Object> responseEntity = httpStatus == HttpStatus.FORBIDDEN
+                ? new ResponseEntity<>(forbiddenJson, httpStatus)
+                : new ResponseEntity<>(okJson, httpStatus);
+
         when(restTemplate.exchange(
                 Mockito.anyString(),
                 Mockito.<HttpMethod>eq(HttpMethod.GET),
                 Mockito.<HttpEntity<?>>any(),
                 Mockito.<Class<Object>>any()
-        )).thenReturn(responseEntity200);
+        )).thenReturn(responseEntity);
     }
 }

--- a/src/test/java/no/nav/syfo/services/TilgangServiceTest.java
+++ b/src/test/java/no/nav/syfo/services/TilgangServiceTest.java
@@ -28,7 +28,7 @@ public class TilgangServiceTest {
     public void godkjennMocketTilgang() {
         tilgangService = new TilgangService(TILGANGSKONTROLL_URL, HAR_LOCAL_MOCK, restTemplate, contextHolder);
 
-        Boolean tilgang = tilgangService.sjekkTilgang(FNR);
+        Boolean tilgang = tilgangService.sjekkTilgang(FNR).harTilgang;
 
         assertThat(tilgang).isTrue();
     }


### PR DESCRIPTION
Bruk egen RestTemplateErrorHandler, som ikke gir exception når tilgangskontroll gir 200 eller 403
Returner Tilgang-objekt fra sjekkTilgang, legg begrunnelse i 403response
Send begrunnelse inn som message i HarIkkeTilgang-exception, send videre til frontend via ControllerExceptionHandler