### PR TITLE
Kast FastlegeIkkeFunnet-exception hvis listen med fastleger er tom

### DIFF
--- a/src/main/java/no/nav/syfo/rest/ressurser/FastlegeRessurs.java
+++ b/src/main/java/no/nav/syfo/rest/ressurser/FastlegeRessurs.java
@@ -55,7 +55,11 @@ public class FastlegeRessurs {
 
         kastExceptionHvisIkkeTilgang(fnr);
 
-        return fastlegeService.hentBrukersFastleger(fnr);
+        List<Fastlege> fastleger = fastlegeService.hentBrukersFastleger(fnr);
+        if (fastleger.isEmpty()) {
+            throw new FastlegeIkkeFunnet("Fant ingen fastleger på brukeren");
+        }
+        return fastleger;
     }
 
     private void kastExceptionHvisIkkeTilgang(String fnr) {


### PR DESCRIPTION
Dette fordi frontend forventer 404 når brukeren ikke har noen fastleger