### PR TITLE
Prepare for move to team namespace

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -72,7 +72,7 @@ spec:
     - name: SYFOTILGANGSKONTROLL_CLIENT_ID
       value: "32e36aa5-1d12-452a-9b1e-9f3f557cbb4d"
     - name: NO_NAV_SECURITY_JWT_ISSUER_STS_DISCOVERYURL
-      value: http://security-token-service/rest/v1/sts/.well-known/openid-configuration
+      value: https://security-token-service.nais.preprod.local/rest/v1/sts/.well-known/openid-configuration
     - name: NO_NAV_SECURITY_JWT_ISSUER_STS_ACCEPTEDAUDIENCE
       value: srvsyfooppfolgings
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_DISCOVERYURL
@@ -85,6 +85,8 @@ spec:
       value: https://login.microsoftonline.com/navq.onmicrosoft.com/oauth2/token
     - name: SYFOPARTNERINFO_APPID
       value: 077b7904-dec5-4d2e-bf69-bb17f56658c2
+    - name: SYFOPARTNERINFO_URL
+      value: "https://syfopartnerinfo.dev.intern.nav.no"
     - name: PDL_URL
       value: https://pdl-api.nais.preprod.local/graphql
     - name: SECURITY_TOKEN_SERVICE_REST_URL

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -72,7 +72,7 @@ spec:
     - name: SYFOTILGANGSKONTROLL_CLIENT_ID
       value: "dfaa2699-7390-4459-9cfc-2e8de64dfaf9"
     - name: NO_NAV_SECURITY_JWT_ISSUER_STS_DISCOVERYURL
-      value: http://security-token-service/rest/v1/sts/.well-known/openid-configuration
+      value: https://security-token-service.nais.adeo.no/rest/v1/sts/.well-known/openid-configuration
     - name: NO_NAV_SECURITY_JWT_ISSUER_STS_ACCEPTEDAUDIENCE
       value: srvsyfooppfolgings
     - name: NO_NAV_SECURITY_JWT_ISSUER_VEILEDER_DISCOVERYURL
@@ -85,6 +85,8 @@ spec:
       value: https://login.microsoftonline.com/navno.onmicrosoft.com/oauth2/token
     - name: SYFOPARTNERINFO_APPID
       value: 55732aaa-9976-4a7b-8342-2e502a3cdce4
+    - name: SYFOPARTNERINFO_URL
+      value: "https://syfopartnerinfo.intern.nav.no"
     - name: PDL_URL
       value: https://pdl-api.nais.adeo.no/graphql
     - name: SECURITY_TOKEN_SERVICE_REST_URL

--- a/src/main/java/no/nav/syfo/services/DialogService.java
+++ b/src/main/java/no/nav/syfo/services/DialogService.java
@@ -38,7 +38,7 @@ public class DialogService {
         this.partnerService = partnerService;
         this.restTemplate = restTemplate;
         this.stsConsumer = stsConsumer;
-        this.dialogfordelerDomain = "local".equalsIgnoreCase(environmenName) ? "localhost:8080" : "dialogfordeler";
+        this.dialogfordelerDomain = "local".equalsIgnoreCase(environmenName) ? "localhost:8080" : "dialogfordeler.default";
     }
 
     public void sendOppfolgingsplan(final RSOppfolgingsplan oppfolgingsplan) {

--- a/src/main/kotlin/no/nav/syfo/consumer/syfopartnerinfo/SyfoPartnerInfoConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/syfopartnerinfo/SyfoPartnerInfoConsumer.kt
@@ -17,13 +17,14 @@ class SyfoPartnerInfoConsumer(
     private val azureAdTokenConsumer: AzureAdTokenConsumer,
     private val metrikk: Metrikk,
     @Qualifier("Oidc") private val restTemplate: RestTemplate,
-    @Value("\${syfopartnerinfo.appid}") private val syfoPartnerInfoAppId: String
+    @Value("\${syfopartnerinfo.appid}") private val syfoPartnerInfoAppId: String,
+    @Value("\${syfopartnerinfo.url}") private val syfopartnerinfoUrl: String
 ) {
 
     fun getPartnerId(herId: String): List<PartnerInfoResponse> {
         try {
             val response = restTemplate.exchange(
-                "$SYFOPARTNERINFO_BASEURL/api/v1/behandler?herid=$herId",
+                "$syfopartnerinfoUrl/api/v1/behandler?herid=$herId",
                 HttpMethod.GET,
                 entity(syfoPartnerInfoAppId),
                 object : ParameterizedTypeReference<List<PartnerInfoResponse>>() {}
@@ -47,7 +48,6 @@ class SyfoPartnerInfoConsumer(
 
     companion object {
         private val LOG = LoggerFactory.getLogger(SyfoPartnerInfoConsumer::class.java)
-        private const val SYFOPARTNERINFO_BASEURL = "http://syfopartnerinfo"
         private const val CALL_SYFOPARTNERINFO_BEHANDLER_SUCCESS = "call_azuread_token_system_success"
     }
 

--- a/src/test/kotlin/no/nav/syfo/consumer/SyfoPartnerInfoConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/consumer/SyfoPartnerInfoConsumerTest.kt
@@ -44,6 +44,9 @@ class SyfoPartnerInfoConsumerTest {
     @MockBean
     lateinit var metrikk: Metrikk
 
+    @Value("\${syfopartnerinfo.url}")
+    private lateinit var syfopartnerinfoUrl: String
+
     @Inject
     @Qualifier(value = "Oidc")
     lateinit var restTemplate: RestTemplate
@@ -64,7 +67,13 @@ class SyfoPartnerInfoConsumerTest {
         mockAzureAD()
         mockSyfopartnerinfo()
 
-        syfoPartnerInfoConsumer = SyfoPartnerInfoConsumer(azureAdTokenConsumer = azureAdTokenConsumer, metrikk = metrikk, restTemplate = restTemplate, syfoPartnerInfoAppId = "")
+        syfoPartnerInfoConsumer = SyfoPartnerInfoConsumer(
+            azureAdTokenConsumer = azureAdTokenConsumer,
+            metrikk = metrikk,
+            restTemplate = restTemplate,
+            syfoPartnerInfoAppId = "",
+            syfopartnerinfoUrl = syfopartnerinfoUrl
+        )
     }
 
     @Test
@@ -78,10 +87,10 @@ class SyfoPartnerInfoConsumerTest {
     }
 
     private fun mockSyfopartnerinfo() {
-        val URL = "http://syfopartnerinfo/api/v1/behandler?herid=$HER_ID"
+        val url = "$syfopartnerinfoUrl/api/v1/behandler?herid=$HER_ID"
         val infoResponse: MutableList<PartnerInfoResponse>? = null
 
-        mockRestServiceServer.expect(ExpectedCount.manyTimes(), MockRestRequestMatchers.requestTo(URL))
+        mockRestServiceServer.expect(ExpectedCount.manyTimes(), MockRestRequestMatchers.requestTo(url))
                 .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
                 .andRespond(MockRestResponseCreators.withSuccess(objectMapper.writeValueAsString(infoResponse), MediaType.APPLICATION_JSON))
     }

--- a/src/test/kotlin/no/nav/syfo/services/DialogServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/services/DialogServiceTest.kt
@@ -43,6 +43,9 @@ class DialogServiceTest {
     lateinit var mockRestServiceServer: MockRestServiceServer
     lateinit var mockDefaultRestServiceServer: MockRestServiceServer
 
+    @Value("\${syfopartnerinfo.url}")
+    private lateinit var syfopartnerinfoUrl: String
+
     @Value("\${security.token.service.rest.url}")
     private lateinit var stsUrl: String
 
@@ -176,12 +179,12 @@ class DialogServiceTest {
     }
 
     private fun mockSyfopartnerinfo() {
-        val URL = "http://syfopartnerinfo/api/v1/behandler?herid=$HER_ID"
+        val url = "$syfopartnerinfoUrl/api/v1/behandler?herid=$HER_ID"
         val partnerInfoResponse = PartnerInfoResponse(PARTNER_ID)
         val infoResponse: MutableList<PartnerInfoResponse> = ArrayList() // listOf(ResponseEntity<List<PartnerInfoResponse>>(infoResponse, HttpStatus.OK))
         infoResponse.add(partnerInfoResponse)
 
-        mockRestServiceServer.expect(ExpectedCount.manyTimes(), MockRestRequestMatchers.requestTo(URL))
+        mockRestServiceServer.expect(ExpectedCount.manyTimes(), MockRestRequestMatchers.requestTo(url))
             .andExpect(MockRestRequestMatchers.method(HttpMethod.GET))
             .andRespond(MockRestResponseCreators.withSuccess(objectMapper.writeValueAsString(infoResponse), MediaType.APPLICATION_JSON))
     }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -31,6 +31,7 @@ client.secret: "clientSecret"
 
 syfotilgangskontroll.client.id: "syfopartnerinfoId"
 syfopartnerinfo.appid: "syfopartnerinfoId"
+syfopartnerinfo.url: "https://syfopartnerinfourl"
 
 ad.accesstoken.url: "http://aadaccesstoken"
 


### PR DESCRIPTION
Cannot use implicit namespace in host for urls to external NAIS service. User ingress url for Syfopartnerinfo and explicit namespace for Dialogfordeler.