### PR TITLE
Add Azure V2 token for system calls

### DIFF
--- a/src/main/kotlin/no/nav/syfo/consumer/tilgangskontroll/TilgangkontrollConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/consumer/tilgangskontroll/TilgangkontrollConsumer.kt
@@ -59,7 +59,7 @@ class TilgangkontrollConsumer @Inject constructor(
 
     fun accessAzureAdV2(fnr: String): Tilgang {
         val token = tokenFraOIDC(contextHolder, OIDCIssuer.VEILEDER_AZURE_V2)
-        val oboToken = azureAdV2TokenConsumer.getOnBehalfOfToken(
+        val oboToken = azureAdV2TokenConsumer.getToken(
             scopeClientId = syfotilgangskontrollClientId,
             token = token
         )


### PR DESCRIPTION
Nå kan man få V2-token enten i on-behalf-of-flow, eller for systemkall, avhengig av om man sender med et eksisterende token eller ikke.