### PR TITLE
Reduserer støy i loggen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ val kotlinJacksonVersion = "2.11.3"
 val logstashVersion = "6.3"
 val prometheusVersion = "1.5.5"
 val slf4jVersion = "1.7.25"
+val janinoVersion = "3.1.6"
 val swaggerVersion = "1.5.21"
 val tokenValidationSpringSupportVersion = "1.3.2"
 
@@ -115,6 +116,7 @@ dependencies {
     implementation("javax.ws.rs:javax.ws.rs-api:$javaxWsRsApiVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
+    implementation("org.codehaus.janino:janino:$janinoVersion")
 
     testImplementation("no.nav.security:token-validation-test-support:$tokenValidationSpringSupportVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/resources/logback-remote.xml
+++ b/src/main/resources/logback-remote.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
     <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.JaninoEventEvaluator">
+                <expression>return (
+                    message.contains("WS-Addressing - failed to retrieve Message Addressing Properties from context") ||
+                    message.contains("Response message does not contain WS-Addressing properties.  Not correlating response."));
+                </expression>
+            </evaluator>
+            <OnMismatch>NEUTRAL</OnMismatch>
+            <OnMatch>DENY</OnMatch>
+        </filter>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 


### PR DESCRIPTION
Ser at prod-loggene flommer over av 
"WS-Addressing - failed to retrieve Message Addressing Properties from context"
og
"Response message does not contain WS-Addressing properties.  Not correlating response.". 

Håper denne tilpasningen fjerner dette. Har deployet i dev-fss for å få verifisert.