### PR TITLE
Remove obsolete ingresses

### DIFF
--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -34,8 +34,6 @@ spec:
     path: fastlegerest/internal/prometheus
   ingresses:
     - "https://fastlegerest.intern.nav.no"
-    - "https://fastlegerest.prod-fss-pub.nais.io"
-    - "https://fastlegerest.nais.adeo.no"
   accessPolicy:
     inbound:
       rules:


### PR DESCRIPTION
Fikk et tips fra noen på nais-teamet om at disse bør fjernes siden de i alle fall vil slutte å virke om noen dager. 

Så vidt jeg kan se er de ikke i bruk - bare uteglemt opprydning etter at app'en ble migrert til gcp.