### PR TITLE
IS-1982: hente detaljer for behandlerkontor

### DIFF
--- a/src/main/kotlin/no/nav/syfo/fastlege/FastlegeService.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/FastlegeService.kt
@@ -66,7 +66,7 @@ class FastlegeService(
 
     fun hentBehandlereForKontor(
         kontorHerId: Int,
-    ): List<Behandler> =
+    ): BehandlerKontor? =
         adresseregisterClient.hentBehandlereForKontor(kontorHerId)
 
     private fun toPasient(

--- a/src/main/kotlin/no/nav/syfo/fastlege/FastlegeService.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/FastlegeService.kt
@@ -67,7 +67,7 @@ class FastlegeService(
     fun hentBehandlereForKontor(
         kontorHerId: Int,
     ): BehandlerKontor? =
-        adresseregisterClient.hentBehandlereForKontor(kontorHerId)
+        adresseregisterClient.hentBehandlerKontor(kontorHerId)
 
     private fun toPasient(
         personIdent: PersonIdent,

--- a/src/main/kotlin/no/nav/syfo/fastlege/FastlegeService.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/FastlegeService.kt
@@ -64,7 +64,7 @@ class FastlegeService(
         ).vikar()
     }
 
-    fun hentBehandlereForKontor(
+    fun hentBehandlerKontor(
         kontorHerId: Int,
     ): BehandlerKontor? =
         adresseregisterClient.hentBehandlerKontor(kontorHerId)

--- a/src/main/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApi.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApi.kt
@@ -65,7 +65,7 @@ fun Route.registrerFastlegeSystemApi(
                 token = token,
             )
 
-            val behandlerKontor = fastlegeService.hentBehandlereForKontor(kontorHerId)
+            val behandlerKontor = fastlegeService.hentBehandlerKontor(kontorHerId)
             if (behandlerKontor != null) {
                 call.respond(behandlerKontor)
             } else {

--- a/src/main/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApi.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApi.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.fastlege.api.system
 
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -64,8 +65,12 @@ fun Route.registrerFastlegeSystemApi(
                 token = token,
             )
 
-            val behandlere = fastlegeService.hentBehandlereForKontor(kontorHerId)
-            call.respond(behandlere)
+            val behandlerKontor = fastlegeService.hentBehandlereForKontor(kontorHerId)
+            if (behandlerKontor != null) {
+                call.respond(behandlerKontor)
+            } else {
+                call.respond(HttpStatusCode.NoContent)
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/fastlege/domain/BehandlerKontor.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/domain/BehandlerKontor.kt
@@ -2,9 +2,9 @@ package no.nav.syfo.fastlege.domain
 
 data class BehandlerKontor(
     val aktiv: Boolean,
-    val her_id: Int,
+    val herId: Int,
     val navn: String,
-    val besoeksadresse: Adresse?,
+    val besoksadresse: Adresse?,
     val postadresse: Adresse?,
     val telefon: String?,
     val epost: String?,

--- a/src/main/kotlin/no/nav/syfo/fastlege/domain/BehandlerKontor.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/domain/BehandlerKontor.kt
@@ -1,0 +1,13 @@
+package no.nav.syfo.fastlege.domain
+
+data class BehandlerKontor(
+    val aktiv: Boolean,
+    val her_id: Int,
+    val navn: String,
+    val besoeksadresse: Adresse?,
+    val postadresse: Adresse?,
+    val telefon: String?,
+    val epost: String?,
+    val orgnummer: String?,
+    val behandlere: List<Behandler>,
+)

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterClient.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterClient.kt
@@ -38,14 +38,14 @@ class AdresseregisterClient(
             throw e
         }
 
-    fun hentBehandlereForKontor(parentHerId: Int) =
+    fun hentBehandlerKontor(parentHerId: Int) =
         try {
             val wsOrg = adresseregisterSoapClient.getOrganizationDetails(parentHerId)
             BehandlerKontor(
                 aktiv = wsOrg.isActive,
-                her_id = wsOrg.herId,
+                herId = wsOrg.herId,
                 navn = wsOrg.name,
-                besoeksadresse = extractPhysicalAddress(wsOrg, "RES"),
+                besoksadresse = extractPhysicalAddress(wsOrg, "RES"),
                 postadresse = extractPhysicalAddress(wsOrg, "PST"),
                 telefon = extractElectronicAddressField(wsOrg, "E_TLF"),
                 epost = extractElectronicAddressField(wsOrg, "E_EDI"),

--- a/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterClient.kt
+++ b/src/main/kotlin/no/nav/syfo/fastlege/ws/adresseregister/AdresseregisterClient.kt
@@ -1,10 +1,13 @@
 package no.nav.syfo.fastlege.ws.adresseregister
 
 import no.nav.syfo.fastlege.*
+import no.nav.syfo.fastlege.domain.Adresse
 import no.nav.syfo.fastlege.domain.Behandler
+import no.nav.syfo.fastlege.domain.BehandlerKontor
 import no.nhn.register.communicationparty.ICommunicationPartyService
 import no.nhn.register.communicationparty.ICommunicationPartyServiceGetOrganizationDetailsGenericFaultFaultFaultMessage
 import no.nhn.register.communicationparty.ICommunicationPartyServiceGetOrganizationPersonDetailsGenericFaultFaultFaultMessage
+import no.nhn.register.communicationparty.WSOrganization
 import org.slf4j.LoggerFactory
 
 class AdresseregisterClient(
@@ -38,20 +41,30 @@ class AdresseregisterClient(
     fun hentBehandlereForKontor(parentHerId: Int) =
         try {
             val wsOrg = adresseregisterSoapClient.getOrganizationDetails(parentHerId)
-            wsOrg.people.organizationPersons.map { orgPerson ->
-                Behandler(
-                    aktiv = orgPerson.isActive,
-                    herId = orgPerson.herId,
-                    personIdent = orgPerson.person.citizenId.id,
-                    hprId = orgPerson.person.hprInformation.hprNumber,
-                    fornavn = orgPerson.person.firstName,
-                    mellomnavn = orgPerson.person.middleName,
-                    etternavn = orgPerson.person.lastName,
-                    kategori = orgPerson.person.hprInformation.authorizations?.authorizations?.map { aut ->
-                        aut.profession?.codeValue
-                    }?.firstOrNull()
-                )
-            }.also {
+            BehandlerKontor(
+                aktiv = wsOrg.isActive,
+                her_id = wsOrg.herId,
+                navn = wsOrg.name,
+                besoeksadresse = extractPhysicalAddress(wsOrg, "RES"),
+                postadresse = extractPhysicalAddress(wsOrg, "PST"),
+                telefon = extractElectronicAddressField(wsOrg, "E_TLF"),
+                epost = extractElectronicAddressField(wsOrg, "E_EDI"),
+                orgnummer = wsOrg.organizationNumber?.toString(),
+                behandlere = wsOrg.people.organizationPersons.map { orgPerson ->
+                    Behandler(
+                        aktiv = orgPerson.isActive,
+                        herId = orgPerson.herId,
+                        personIdent = orgPerson.person.citizenId.id,
+                        hprId = orgPerson.person.hprInformation.hprNumber,
+                        fornavn = orgPerson.person.firstName,
+                        mellomnavn = orgPerson.person.middleName,
+                        etternavn = orgPerson.person.lastName,
+                        kategori = orgPerson.person.hprInformation.authorizations?.authorizations?.map { aut ->
+                            aut.profession?.codeValue
+                        }?.firstOrNull()
+                    )
+                },
+            ).also {
                 COUNT_ADRESSEREGISTER_BEHANDLERE_SUCCESS.increment()
             }
         } catch (e: ICommunicationPartyServiceGetOrganizationDetailsGenericFaultFaultFaultMessage) {
@@ -61,7 +74,7 @@ class AdresseregisterClient(
                 parentHerId,
                 e
             )
-            emptyList()
+            null
         } catch (e: RuntimeException) {
             COUNT_ADRESSEREGISTER_BEHANDLERE_FAIL.increment()
             log.error(
@@ -71,6 +84,38 @@ class AdresseregisterClient(
             )
             throw e
         }
+
+    private fun extractPhysicalAddress(wsOrg: WSOrganization, field: String) =
+        wsOrg.physicalAddresses?.physicalAddresses?.stream()
+            ?.filter { wsAddress ->
+                wsAddress.type != null &&
+                    wsAddress.type.isActive &&
+                    wsAddress.type.codeValue == field
+            }
+            ?.findFirst()
+            ?.map { wsAddress ->
+                Adresse(
+                    adresse = if (wsAddress.postbox.isNullOrBlank()) wsAddress.streetAddress else wsAddress.postbox,
+                    postnummer = postnummer(wsAddress.postalCode),
+                    poststed = wsAddress.city,
+                )
+            }
+            ?.orElse(null)
+
+    private fun extractElectronicAddressField(wsOrg: WSOrganization, field: String) =
+        wsOrg.electronicAddresses?.electronicAddresses?.stream()
+            ?.filter { it.type.codeValue == field }
+            ?.findFirst()
+            ?.map { it.address }
+            ?.orElse("")
+
+    private fun postnummer(postalCode: Int): String {
+        val postnummer = StringBuilder(postalCode.toString())
+        while (postnummer.length < 4) {
+            postnummer.insert(0, "0")
+        }
+        return postnummer.toString()
+    }
 
     companion object {
         private val log = LoggerFactory.getLogger(AdresseregisterClient::class.java)

--- a/src/test/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApiTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.http.*
 import io.ktor.server.testing.*
-import no.nav.syfo.fastlege.domain.Behandler
+import no.nav.syfo.fastlege.domain.BehandlerKontor
 import no.nav.syfo.fastlege.domain.Fastlege
 import no.nav.syfo.fastlege.domain.RelasjonKodeVerdi
 import no.nav.syfo.testhelper.*
@@ -97,9 +97,10 @@ class FastlegeSystemApiTest : Spek({
                             }
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
-                            val behandlere = objectMapper.readValue<List<Behandler>>(response.content!!)
-                            behandlere.size shouldBeEqualTo 1
-                            val behandler = behandlere[0]
+                            val behandlerKontor = objectMapper.readValue<BehandlerKontor>(response.content!!)
+                            behandlerKontor.aktiv shouldBeEqualTo true
+                            behandlerKontor.behandlere.size shouldBeEqualTo 1
+                            val behandler = behandlerKontor.behandlere[0]
                             behandler.aktiv shouldBeEqualTo true
                             behandler.etternavn shouldBeEqualTo UserConstants.FASTLEGE_ETTERNAVN
                             behandler.hprId shouldBeEqualTo UserConstants.FASTLEGE_HPR_NR
@@ -115,11 +116,12 @@ class FastlegeSystemApiTest : Spek({
                             }
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.OK
-                            val behandlere = objectMapper.readValue<List<Behandler>>(response.content!!)
-                            behandlere.size shouldBeEqualTo 2
-                            val behandler = behandlere[0]
+                            val behandlerKontor = objectMapper.readValue<BehandlerKontor>(response.content!!)
+                            behandlerKontor.aktiv shouldBeEqualTo true
+                            behandlerKontor.behandlere.size shouldBeEqualTo 2
+                            val behandler = behandlerKontor.behandlere[0]
                             behandler.aktiv shouldBeEqualTo true
-                            val behandlerInactive = behandlere[1]
+                            val behandlerInactive = behandlerKontor.behandlere[1]
                             behandlerInactive.aktiv shouldBeEqualTo false
                         }
                     }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/AdresseregisterMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/AdresseregisterMock.kt
@@ -1,6 +1,8 @@
 package no.nav.syfo.testhelper.mock
 
 import com.microsoft.schemas._2003._10.serialization.arrays.WSArrayOfint
+import no.nav.syfo.testhelper.UserConstants.FASTLEGEKONTOR_NAVN
+import no.nav.syfo.testhelper.UserConstants.FASTLEGEKONTOR_ORGNR
 import no.nav.syfo.testhelper.UserConstants.FASTLEGE_ETTERNAVN
 import no.nav.syfo.testhelper.UserConstants.FASTLEGE_FNR
 import no.nav.syfo.testhelper.UserConstants.FASTLEGE_FNR_INACTIVE
@@ -61,6 +63,10 @@ class AdresseregisterMock : ICommunicationPartyService {
             throw ICommunicationPartyServiceGetOrganizationPersonDetailsGenericFaultFaultFaultMessage()
         }
         return WSOrganization()
+            .withActive(true)
+            .withHerId(parentHerId)
+            .withName(FASTLEGEKONTOR_NAVN)
+            .withOrganizationNumber(FASTLEGEKONTOR_ORGNR)
             .withPeople(
                 WSArrayOfOrganizationPerson()
                     .withOrganizationPersons(


### PR DESCRIPTION
Ser at vi har en del kontorer i databasen til isdialogmelding som har blitt inaktive i Adresseregisteret. Så foreslår at vi løser dette i den samme cronjob'en som skal oppdatere behandlere. 

Endrer derfor API'et til fastlegerest slik at den henter ut noen detaljer om kontoret i tillegg til lista med behandlere. I første omgang er det kanskje mest interessant om aktiv er true eller false, men kan vurdere å bruke noen av de andre detaljene også for å oppdatere kontor-informasjonen i isdialogmelding.