### PR TITLE
IS-3348: Erstattet bruk av kotlin.test.asserts med JUnit

### DIFF
--- a/src/test/kotlin/no/nav/syfo/fastlege/api/FastlegeAzureADApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/fastlege/api/FastlegeAzureADApiTest.kt
@@ -17,10 +17,10 @@ import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
 import no.nav.syfo.testhelper.generateJWTNavIdent
 import no.nav.syfo.testhelper.testApiModule
 import no.nav.syfo.util.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 class FastlegeAzureADApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/fastlege/api/system/FastlegeSystemApiTest.kt
@@ -15,12 +15,12 @@ import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.testhelper.UserConstants.PARENT_HER_ID
 import no.nav.syfo.testhelper.UserConstants.PARENT_HER_ID_WITH_INACTIVE_BEHANDLER
 import no.nav.syfo.util.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class FastlegeSystemApiTest {
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Ved overgang til JUnit i tidligere [PR](https://github.com/navikt/fastlegerest/pull/200) så ble `kotlin.test.asserts` feilaktig lagt til i stedet for JUnit.
