### PR TITLE
IS-3841: Tilpasse tilgangskontroll til å bruke eget endepunkt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,9 +6,9 @@ version = "0.0.1"
 
 val commonsCollectionVersion = "3.2.2"
 val commonsTextVersion = "1.15.0"
-val cxfVersion = "3.6.5"
-val jacksonVersion = "2.21.1"
+val cxfVersion = "3.6.10"
 val jacksonDataTypeVersion = "2.21.1"
+val jacksonDatabindVersion = "3.1.0"
 val javaxActivationVersion = "1.2.0"
 val javaxWsRsApiVersion = "2.1.1"
 val jaxbVersion = "2.3.1"
@@ -66,7 +66,6 @@ dependencies {
             strictly(commonsCollectionVersion)
         }
     }
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion")
     implementation("javax.xml.bind:jaxb-api:$jaxbVersion")
     implementation("org.glassfish.jaxb:jaxb-runtime:$jaxbVersion")
 
@@ -83,7 +82,8 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$micrometerRegistryVersion")
 
     // (De-)serialization
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion")
+    implementation("tools.jackson.core:jackson-databind:$jacksonDatabindVersion")
 
     // Cache
     implementation("redis.clients:jedis:$jedisVersion")

--- a/src/main/kotlin/no/nav/syfo/client/tilgangskontroll/VeilederTilgangskontrollClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/tilgangskontroll/VeilederTilgangskontrollClient.kt
@@ -17,7 +17,7 @@ class VeilederTilgangskontrollClient(
     private val clientEnvironment: ClientEnvironment,
 ) {
     private val httpClient = httpClientDefault()
-    private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_PERSON_PATH"
+    private val tilgangskontrollPersonUrl = "${clientEnvironment.baseUrl}$TILGANGSKONTROLL_FASTLEGE_PERSON_PATH"
 
     suspend fun hasAccess(
         callId: String,
@@ -62,6 +62,6 @@ class VeilederTilgangskontrollClient(
     companion object {
         private val log = LoggerFactory.getLogger(VeilederTilgangskontrollClient::class.java)
 
-        const val TILGANGSKONTROLL_PERSON_PATH = "/api/tilgang/navident/person"
+        const val TILGANGSKONTROLL_FASTLEGE_PERSON_PATH = "/api/tilgang/navident/fastlege/person"
     }
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/VeilederTilgangskontrollMock.kt
@@ -1,6 +1,5 @@
 package no.nav.syfo.testhelper.mock
 
-import io.ktor.server.application.*
 import io.ktor.http.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
@@ -8,7 +7,7 @@ import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.application.api.authentication.installContentNegotiation
 import no.nav.syfo.client.tilgangskontroll.Tilgang
-import no.nav.syfo.client.tilgangskontroll.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_PERSON_PATH
+import no.nav.syfo.client.tilgangskontroll.VeilederTilgangskontrollClient.Companion.TILGANGSKONTROLL_FASTLEGE_PERSON_PATH
 import no.nav.syfo.testhelper.UserConstants.ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS
 import no.nav.syfo.testhelper.getRandomPort
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
@@ -30,7 +29,7 @@ class VeilederTilgangskontrollMock {
     ) {
         installContentNegotiation()
         routing {
-            get(TILGANGSKONTROLL_PERSON_PATH) {
+            get(TILGANGSKONTROLL_FASTLEGE_PERSON_PATH) {
                 when {
                     call.request.headers[NAV_PERSONIDENT_HEADER] == ARBEIDSTAKER_PERSONIDENT_VEILEDER_NO_ACCESS.value -> {
                         call.respond(HttpStatusCode.Forbidden, tilgangFalse)


### PR DESCRIPTION
Tilpasning som gjør at Finnfastlege vil fortsette å fungere selv etter overgang til nye tilganger (for brukere som bare har den nye tilgangen for Finnfastlege og ikke vanlig Modia/SYFO-tilgang).