### PR TITLE
Revert "add dokumentinnhenting aap to inbound access policy (#230)"

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -44,8 +44,6 @@ spec:
         - application: syfomodiaperson
         - application: finnfastlege
         - application: isdialogmelding
-        - application: dokumentinnhenting
-          namespace: aap
     outbound:
       external:
         - host: "login.microsoftonline.com"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -44,8 +44,6 @@ spec:
         - application: syfomodiaperson
         - application: finnfastlege
         - application: isdialogmelding
-        - application: dokumentinnhenting
-          namespace: aap
     outbound:
       external:
         - host: "login.microsoftonline.com"


### PR DESCRIPTION
De trengte ikke tilgang her likevel. Endte opp med å bruke /api/v1/behandler/personident i isdialogmelding